### PR TITLE
Kubernetes manifest (FIXME: should not require hostNetwork)

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -5,8 +5,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+# host info
     - run: docker info
     - run: docker version
+    - run: cat /proc/cpuinfo
+# test
     - run: DOCKER_BUILDKIT=1 docker build -t aind/aind:local .
     - run: sudo ./hack/install-kmod.sh
     - run: docker run -td --name aind --privileged -p 5900:5900 -v /lib/modules:/lib/modules:ro aind/aind:local

--- a/README.md
+++ b/README.md
@@ -58,13 +58,34 @@ sudo modprobe binder_linux
 docker run -td --name aind --privileged -p 5900:5900 -v /lib/modules:/lib/modules:ro aind/aind
 ```
 
-> NOTE: `--privileged` is required for nesting an Anbox (LXC) inside Docker. But you don't need to worry too much because Anbox launches "unprivileged" LXC using user namespaces. You can confirm that all Android processes are running as non-root users, by executing `docker exec aind ps -ef`.
+> **NOTE**: `--privileged` is required for nesting an Anbox (LXC) inside Docker. But you don't need to worry too much because Anbox launches "unprivileged" LXC using user namespaces. You can confirm that all Android processes are running as non-root users, by executing `docker exec aind ps -ef`.
 
 Wait for 10-20 seconds until Android processes are shown up in `docker exec aind ps -ef`, and then connect to `5900` via `vncviewer`.
 
 If the application manager doesn't shown up on the VNC screen, try `docker run ...` several times (FIXME).  Also make sure to check `docker logs aind`.
 
 Future version will support connection from Web browsers (of phones and tablets) without VNC.
+
+### Kubernetes
+
+```bash
+kubectl apply -f kube/aind.yaml
+kubectl port-forward service/aind 5900
+```
+
+The manifest contains the kernel module installer as `initContainers`.
+
+Known to work on:
+- Google Kubernetes Engine (GKE) 1.16.8-gke.4 (ubuntu)
+- Google Kubernetes Engine (GKE) 1.16.8-gke.4 (ubuntu\_containerd)
+- Azure Kubernetes Service (AKS) 1.17.3
+
+Known NOT to work on:
+- kind 0.7.0
+
+**FIXME**: `hostNetwork` is required on Kubernetes (not on non-Kube Docker) for some unknown reason. This disables running multiple aind pods on a single node!
+
+## Apps
 
 ### Pre-installed Apps
 * Firefox

--- a/kube/aind.yaml
+++ b/kube/aind.yaml
@@ -1,0 +1,83 @@
+# aind manifest for Kubernetes
+#
+# Known to work on GKE (Ubuntu) and AKS.
+# Known NOT to work on kind.
+#
+# See also FIXME and NOTE lines.
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: aind
+  name: aind
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: aind
+  template:
+    metadata:
+      labels:
+        app: aind
+    spec:
+# FIXME: hostNetwork is required on Kubernetes (not on non-Kube Docker) for some unknown reason.
+# This disables running multiple aind pods on a single node!
+# https://github.com/aind-containers/aind/pull/8
+      hostNetwork: true
+      initContainers:
+      - name: install-kmod
+# NOTE: replace "aind/aind:latest" with "aind/aind@sha256:<digest>" for reproducible deployment.
+        image: aind/aind:latest
+        command: ["/bin/bash"]
+        args: ["-exc", "cp -f /install-kmod.sh /host/tmp/aind-install-kmod.sh && cd /host && chroot . bash /tmp/aind-install-kmod.sh"]
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - name: host-root
+          mountPath: /host
+      containers:
+      - name: aind
+# NOTE: replace "aind/aind:latest" with "aind/aind@sha256:<digest>" for reproducible deployment.
+        image: aind/aind:latest
+        tty: true
+        securityContext:
+          privileged: true
+        ports:
+        - containerPort: 5900
+        volumeMounts:
+        - name: host-lib-modules
+          readOnly: true
+          mountPath: /lib/modules
+        resources:
+          requests:
+            memory: 2048m
+            cpu: 500m
+        livenessProbe:
+          exec:
+            command: ["pgrep", "-f", "org.anbox.appmgr"]
+          initialDelaySeconds: 20
+          periodSeconds: 15
+      volumes:
+      - name: host-root
+        hostPath:
+          path: /
+      - name: host-lib-modules
+        hostPath:
+          path: /lib/modules
+# NOTE: Set the following nodeSelector if you have non-Ubuntu (i.e. cos) node pools on GKE
+#    nodeSelector:
+#      cloud.google.com/gke-os-distribution: ubuntu
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: aind
+  name: aind
+spec:
+  ports:
+  - port: 5900
+    protocol: TCP
+  selector:
+    app: aind


### PR DESCRIPTION
# WIP

Weird, it works  with `docker run` (via https://github.com/justincormack/nsenter1) on both GKE and AKS nodes, but doesn't work with Kube.

 - - -

## GKE (n2-standard-8, Ubuntu 18.04)

```console
user@aind-84dc696c8c-wt5bh:~$ export DISPLAY=:0
user@aind-84dc696c8c-wt5bh:~$ anbox session-manager
[ 2020-04-13 12:07:36] [client.cpp:49@start] Failed to start container: Failed to start container: Failed to start container
[ 2020-04-13 12:07:36] [session_manager.cpp:148@operator()] Lost connection to container manager, terminating.
[ 2020-04-13 12:07:36] [daemon.cpp:61@Run] Container is not running
terminate called after throwing an instance of 'boost::wrapexcept<boost::log::v2_mt_posix::system_error>'
  what():  Failed to set TLS value: Invalid argument
Stack trace (most recent call last) in thread 631:
#16   Object "[0xffffffffffffffff]", at 0xffffffffffffffff, in 
#15   Object "/lib/x86_64-linux-gnu/libc.so.6", at 0x7f98acdc5152, in clone
#14   Object "/lib/x86_64-linux-gnu/libpthread.so.0", at 0x7f98ad135608, in 
#13   Object "/lib/x86_64-linux-gnu/libstdc++.so.6", at 0x7f98acf86c83, in 
#12   Object "anbox", at 0x5618c6d4d2b0, in 
#11   Object "anbox", at 0x5618c6d737ec, in void anbox::Logger::Errorf<char const*>(boost::optional<anbox::Logger::Location> const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, char const*&&)
#10   Object "anbox", at 0x5618c6d75575, in 
#9    Object "/lib/x86_64-linux-gnu/libboost_log.so.1.71.0", at 0x7f98ad5a891a, in boost::log::v2_mt_posix::sources::aux::get_severity_level()
#8    Object "/lib/x86_64-linux-gnu/libboost_log.so.1.71.0", at 0x7f98ad5d3239, in boost::log::v2_mt_posix::aux::thread_specific_base::set_content(void*) const
#7    Object "/lib/x86_64-linux-gnu/libboost_log.so.1.71.0", at 0x7f98ad587cdc, in 
#6    Object "/lib/x86_64-linux-gnu/libboost_log.so.1.71.0", at 0x7f98ad588fb2, in 
#5    Object "/lib/x86_64-linux-gnu/libstdc++.so.6", at 0x7f98acf5a798, in __cxa_throw
#4    Object "/lib/x86_64-linux-gnu/libstdc++.so.6", at 0x7f98acf5a4e6, in std::terminate()
#3    Object "/lib/x86_64-linux-gnu/libstdc++.so.6", at 0x7f98acf5a47b, in 
#2    Object "/lib/x86_64-linux-gnu/libstdc++.so.6", at 0x7f98acf4e950, in 
#1    Object "/lib/x86_64-linux-gnu/libc.so.6", at 0x7f98accc8858, in abort
#0    Object "/lib/x86_64-linux-gnu/libc.so.6", at 0x7f98acce918b, in gsignal
user@aind-84dc696c8c-wt5bh:~$ uname -a
Linux aind-84dc696c8c-wt5bh 5.3.0-1012-gke #13~18.04.1-Ubuntu SMP Tue Feb 4 17:31:13 UTC 2020 x86_64 x86_64 x86_64 GNU/Linux
```

## AKS (Standard_DS2_v2, Ubuntu 16.04)
```console
root@aind-6456bcc7cb-f748g:/# unsudo bash
+ car=bash                                                 
+ shift                                                                                                                + cdr=
++ which bash                                                                                                          
+ exec machinectl shell user@ /usr/bin/bash                                                                            
Connected to the local host. Press ^] three times within 1s to exit session.
user@aind-6456bcc7cb-f748g:~$ export DISPLAY=:0
user@aind-6456bcc7cb-f748g:~$ anbox session-manager
[ 2020-04-13 12:53:12] [client.cpp:49@start] Failed to start container: Failed to start container: Failed to start container
[ 2020-04-13 12:53:12] [session_manager.cpp:148@operator()] Lost connection to container manager, terminating.
[ 2020-04-13 12:53:12] [daemon.cpp:61@Run] Container is not running
[ 2020-04-13 12:53:12] [session_manager.cpp:148@operator()] Lost connection to container manager, terminating.
Stack trace (most recent call last) in thread 454:
#8    Object "[0xffffffffffffffff]", at 0xffffffffffffffff, in 
#7    Object "/lib/x86_64-linux-gnu/libc.so.6", at 0x7f577153a152, in clone
#6    Object "/lib/x86_64-linux-gnu/libpthread.so.0", at 0x7f57718aa608, in 
#5    Object "/lib/x86_64-linux-gnu/libstdc++.so.6", at 0x7f57716fbc83, in 
#4    Object "anbox", at 0x5614afcd9e69, in 
#3    Object "anbox", at 0x5614afc8c9ac, in boost::asio::detail::scheduler::run(boost::system::error_code&)
#2    Object "anbox", at 0x5614afd008ad, in boost::asio::detail::reactive_socket_recv_op<boost::asio::mutable_buffers_1, std::function<void (boost::system::error_code const&, unsigned long)>, boost::asio::detail::io_object_executor<boost::asio::executor> >::do_complete(void*, boost::asio::detail::scheduler_operation*, boost::system::error_code const&, unsigned long)
#1    Object "anbox", at 0x5614afc9b40b, in anbox::container::Client::on_read_size(boost::system::error_code const&, unsigned long)
#0    Object "anbox", at 0x5614afc848a6, in 
Segmentation fault (Address not mapped to object [0x18])
Segmentation fault (core dumped)
user@aind-6456bcc7cb-f748g:~$ uname -a
Linux aind-6456bcc7cb-f748g 4.15.0-1071-azure #76-Ubuntu SMP Wed Feb 12 03:02:44 UTC 2020 x86_64 x86_64 x86_64 GNU/Linux
```