### PR TITLE
auto-generate VNC password

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,11 +56,13 @@ sudo modprobe binder_linux
 
 ```bash
 docker run -td --name aind --privileged -p 5900:5900 -v /lib/modules:/lib/modules:ro aind/aind
+docker exec aind cat /home/user/.vnc/passwdfile
 ```
 
 > **NOTE**: `--privileged` is required for nesting an Anbox (LXC) inside Docker. But you don't need to worry too much because Anbox launches "unprivileged" LXC using user namespaces. You can confirm that all Android processes are running as non-root users, by executing `docker exec aind ps -ef`.
 
 Wait for 10-20 seconds until Android processes are shown up in `docker exec aind ps -ef`, and then connect to `5900` via `vncviewer`.
+The VNC password is stored in `/home/user/.vnc/passwdfile`. The password file can be also overridden by `docker run -v /your/own/passwdfile:/home/user/.vnc/passwdfile:ro"
 
 If the application manager doesn't shown up on the VNC screen, try `docker run ...` several times (FIXME).  Also make sure to check `docker logs aind`.
 

--- a/src/docker-2ndboot.sh
+++ b/src/docker-2ndboot.sh
@@ -10,13 +10,19 @@ trap finish EXIT
 
 cd $(realpath $(dirname $0)/..)
 set -eux
+
+mkdir -p ~/.vnc
+if [ ! -e ~/.vnc/passwdfile ]; then
+    echo $(head /dev/urandom | tr -dc a-z0-9 | head -c 32) > ~/.vnc/passwdfile
+fi
+
 Xvfb &
 export DISPLAY=:0
 
 until [ -e /tmp/.X11-unix/X0 ]; do sleep 1; done
 : FIXME: remove this sleep
 sleep 1
-x11vnc &
+x11vnc -usepw &
 : FIXME: remove this sleep
 sleep 1
 fvwm &
@@ -43,5 +49,5 @@ fi
 
 # done
 figlet "Ready"
-ps -ef
+echo "Hint: the password is stored in $HOME/.vnc/passwdfile"
 exec sleep infinity


### PR DESCRIPTION
Run `docker exec aind cat /home/user/.vnc/passwdfile` to obtain the password.
