### PR TITLE
squashfuse

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ARG BASE=ubuntu:20.04
 
-# Apr 7, 2020
-ARG ANBOX_COMMIT=6d9ada9d10348589a03d8101e7cb9f50d6d0b5fb
+# Apr 14, 2020
+ARG ANBOX_COMMIT=1edeb4f07941aaa65624cea59f1f77c314ad1b97
 
 # Apr 7, 2020
 # NOTE: we can't use lxc 4.0.1 dpkg because of https://github.com/lxc/lxc/issues/3363
@@ -51,6 +51,11 @@ RUN git clone https://github.com/anbox/anbox /anbox
 WORKDIR /anbox
 ARG ANBOX_COMMIT
 RUN git pull && git checkout ${ANBOX_COMMIT}
+COPY ./src/patches/anbox /patches
+# `git am` requires user info to be set
+RUN git config user.email "nobody@example.com" && \
+  git config user.name "AinD Build Script" && \
+  git am /patches/* && git show --summary
 RUN mkdir build && \
   cd build && \
   cmake .. && \
@@ -84,6 +89,8 @@ RUN apt-get update && \
   iptables libcap2 libseccomp2 libselinux1 \
 # anbox deps
   libboost-log1.71.0  libboost-thread1.71.0 libboost-program-options1.71.0 libboost-iostreams1.71.0 libboost-filesystem1.71.0 libegl1-mesa libgles2-mesa libprotobuf-lite17 libsdl2-2.0-0 libsdl2-image-2.0-0 \
+# squashfuse
+  squashfuse fuse3 \
 # adb
   adb \
 # systemd

--- a/src/anbox-container-manager-pre.sh
+++ b/src/anbox-container-manager-pre.sh
@@ -5,11 +5,6 @@ if [ $(id -u) != 0 ]; then
 	exit 1
 fi
 
-# clean up orphan loop devices
-if losetup | grep /aind-android.img; then
-	losetup -J | jq -r '.loopdevices[] | select (."back-file" == "/aind-android.img") | .name' | xargs losetup -d
-fi
-
 # ashmem
 /sbin/modprobe ashmem_linux
 if [ ! -e /dev/ashmem ]; then

--- a/src/anbox-container-manager.service
+++ b/src/anbox-container-manager.service
@@ -6,7 +6,7 @@ Wants=network.target
 [Service]
 ExecStartPre=/usr/local/bin/anbox-container-manager-pre.sh
 ExecStartPre=/usr/local/share/anbox/anbox-bridge.sh start
-ExecStart=/usr/local/bin/anbox container-manager --daemon --data-path=/var/lib/anbox --android-image=/aind-android.img --use-rootfs-overlay
+ExecStart=/usr/local/bin/anbox container-manager --daemon --data-path=/var/lib/anbox --android-image=/aind-android.img --use-rootfs-overlay --use-squashfuse
 ExecStopPost=/usr/local/share/anbox/anbox-bridge.sh stop
 
 [Install]

--- a/src/patches/anbox/0001-container-manager-support-setting-enable-squashfuse-.patch
+++ b/src/patches/anbox/0001-container-manager-support-setting-enable-squashfuse-.patch
@@ -1,0 +1,54 @@
+From 8d44f0d775561d5101c0fe04bcf41816a9aec5de Mon Sep 17 00:00:00 2001
+From: Akihiro Suda <akihiro.suda.cz@hco.ntt.co.jp>
+Date: Fri, 17 Apr 2020 10:38:15 +0900
+Subject: [PATCH] container-manager: support setting --enable-squashfuse
+ explicitly
+
+Signed-off-by: Akihiro Suda <akihiro.suda.cz@hco.ntt.co.jp>
+---
+ src/anbox/cmds/container_manager.cpp | 9 ++++++++-
+ src/anbox/cmds/container_manager.h   | 1 +
+ 2 files changed, 9 insertions(+), 1 deletion(-)
+
+diff --git a/src/anbox/cmds/container_manager.cpp b/src/anbox/cmds/container_manager.cpp
+index 307001d..ee1b618 100644
+--- a/src/anbox/cmds/container_manager.cpp
++++ b/src/anbox/cmds/container_manager.cpp
+@@ -55,6 +55,9 @@ anbox::cmds::ContainerManager::ContainerManager()
+   flag(cli::make_flag(cli::Name{"use-rootfs-overlay"},
+                       cli::Description{"Use an overlay for the Android rootfs"},
+                       enable_rootfs_overlay_));
++  flag(cli::make_flag(cli::Name{"use-squashfuse"},
++                      cli::Description{"Use squashfuse for mounting the Android rootfs"},
++                      enable_squashfuse_));
+   flag(cli::make_flag(cli::Name{"container-network-address"},
+                       cli::Description{"Assign the specified network address to the Android container"},
+                       container_network_address_));
+@@ -147,7 +150,11 @@ bool anbox::cmds::ContainerManager::setup_mounts() {
+   // for some cases (unprivileged containers) where no loop support
+   // is available we do the mount instead via squashfuse which will
+   // work entirely in userspace.
+-  if (fs::exists("/dev/loop-control")) {
++  if (!fs::exists("/dev/loop-control")) {
++      WARNING("/dev/loop-control not found. Implying --use-squashfuse");
++      enable_squashfuse_ = true;
++  }
++  if (!enable_squashfuse_) {
+     std::shared_ptr<common::LoopDevice> loop_device;
+ 
+     try {
+diff --git a/src/anbox/cmds/container_manager.h b/src/anbox/cmds/container_manager.h
+index 4fb151a..77ac47d 100644
+--- a/src/anbox/cmds/container_manager.h
++++ b/src/anbox/cmds/container_manager.h
+@@ -45,6 +45,7 @@ class ContainerManager : public cli::CommandWithFlagsAndAction {
+   bool privileged_ = false;
+   bool daemon_ = false;
+   bool enable_rootfs_overlay_ = false;
++  bool enable_squashfuse_ = false;
+   std::string container_network_address_;
+   std::string container_network_gateway_;
+   std::string container_network_dns_servers_;
+-- 
+2.20.1
+


### PR DESCRIPTION
Switch to squashfuse for eliminating loop device issues of real squashfs.
We should switch back to squashfs when loopfs gets upstreamed.

Fix #5 

- - -
PR: https://github.com/anbox/anbox/pull/1426